### PR TITLE
refactor: rename Coreon to Sparkify across codebase; docs: massive RE…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
 ## Summary
 
-This PR introduces Coreon (advanced PHP framework) and a Next.js TypeScript frontend, with full dev tooling and Docker support.
+This PR introduces or updates Sparkify (advanced PHP framework) and the Sparkify Next.js (TypeScript) frontend, with full dev tooling and Docker support.
 
 ## Changes
-- Coreon framework with DI, routing, middleware (errors, CORS, JSON), logging, env/config, console, Doctrine DBAL
+- Sparkify framework with DI, routing, middleware (errors, CORS, JSON, request ID, request logging), logging, env/config, console, Doctrine DBAL
 - API endpoints: `/api/health`, `/api/v1/hello/{name}`
-- Next.js 14 app (TypeScript, Tailwind, App Router) proxying `/api/*` to Coreon
+- Next.js 14 app (TypeScript, Tailwind, App Router) proxying `/api/*` to Sparkify
 - Dockerfiles and docker-compose for one-command local dev
-- Basic PHPUnit setup and a starter test
+- PHPUnit setup and a starter test
+- Linting/config: EditorConfig, ESLint (web), PHP CS Fixer (php), GitHub Actions CI
 
 ## How to test
 1. Docker

--- a/README.md
+++ b/README.md
@@ -1,38 +1,78 @@
-# Coreon
+# Sparkify
 
-Coreon is an advanced, modular PHP framework paired with a Next.js (TypeScript) frontend. It emphasizes performance, developer ergonomics, and modern tooling.
+Sparkify is an advanced, modular PHP framework designed for building high-performance APIs and full-stack applications. It ships with a modern TypeScript/Next.js frontend and a batteries-included developer experience.
+
+Sparkify focuses on: developer ergonomics, explicitness over magic, performance-first routing and middleware, clean architecture, and pragmatic tooling.
+
+## Table of contents
+- Overview
+- Features
+- Architecture
+- Request lifecycle
+- Directory layout
+- Getting started (Docker, Local)
+- Configuration and environments
+- HTTP: Routing, Controllers, Middleware
+- HTTP: Error handling, CORS, JSON, Request IDs, Logging
+- DI Container and Services
+- Database with Doctrine DBAL
+- Logging strategy
+- CLI tooling
+- Frontend (Next.js)
+- API examples
+- Security and CORS
+- Testing (PHPUnit)
+- Linting & formatting
+- CI/CD
+- Observability & Deployment notes
+- Roadmap
+- Contributing
+- Code of Conduct
+- License
+
+## Overview
+Sparkify pairs a lightweight PHP 8+ runtime (FastRoute, HttpFoundation, PHP-DI) with a rich middleware pipeline and a fully-typed Next.js 14 frontend. Out-of-the-box, Sparkify gives you a coherent stack for shipping production-grade APIs and web apps.
 
 ## Features
 - PHP 8+ framework with:
   - Dependency Injection (PHP-DI)
   - FastRoute router with controller DI and middleware pipeline
   - Symfony HttpFoundation for requests/responses
-  - Monolog logging, Whoops error pages in debug
-  - Dotenv configuration, typed env helpers, central Config repository
+  - Monolog logging with request logging and correlation (X-Request-Id)
+  - Whoops pretty error pages in debug
+  - Dotenv configuration, typed env helpers, centralized Config repository
   - Doctrine DBAL for database access
-  - CORS and JSON body parsing middleware
+  - CORS, JSON body parsing middleware
+  - RequestId and RequestLogging middleware
   - Symfony Console CLI (e.g., route:list)
-- Next.js 14 App Router frontend with TypeScript and Tailwind
-- API gateway: Next.js rewrites `/api/*` to Coreon (`:8000`)
+- Next.js 14 App Router (TypeScript + Tailwind)
+- Reverse-proxy rewrites from web to API (`/api/*` -> `:8000`)
 - Dockerized dev environment for one-command startup
-- Testing (PHPUnit), EditorConfig, Code of Conduct, Contributing guide, MIT license
+- Testing (PHPUnit), EditorConfig, ESLint, PHP CS Fixer, GitHub Actions CI
 
 ## Architecture
-- `coreon/` — framework core and app layer
+- `coreon/` — Sparkify PHP framework + app layer
   - `src/Core` — framework internals (kernel, router, middleware, support)
   - `app/Http/Controllers` — application controllers
-  - `routes/` — `web.php` and `api.php`
+  - `routes/` — define `web.php` and `api.php`
   - `config/` — environment, CORS, services
 - `web/` — Next.js app (App Router, TS, Tailwind)
 
-Request lifecycle:
-1. HTTP request enters `public/index.php`
+## Request lifecycle
+1. HTTP request hits `public/index.php`
 2. `Application` bootstraps env, config, container, logger
-3. `HttpKernel` runs middleware: ErrorHandling -> CORS -> JSON parser -> Routing
-4. `Router` dispatches to controller via DI, `ResponseFactory` normalizes output
+3. `HttpKernel` applies middleware in order:
+   - ErrorHandling -> RequestId -> RequestLogging -> CORS -> JSON Body -> Routing
+4. `Router` resolves and invokes controller via DI
+5. `ResponseFactory` normalizes controller return into an HTTP response
+
+## Directory layout
+- `coreon/src/Core` — framework (do not couple app to internals)
+- `coreon/app` — your app layer (controllers, services, domain)
+- `coreon/routes` — declarative route definitions
+- `web/app` — Next.js routes and pages
 
 ## Getting started
-
 ### Docker (recommended)
 ```bash
 docker compose up --build
@@ -56,30 +96,79 @@ npm run dev
 # http://localhost:3000
 ```
 
-## Configuration
-- Copy and adjust `.env` in `coreon/`
-- Key settings: `APP_ENV`, `APP_DEBUG`, `APP_URL`, DB connection or `DATABASE_URL`, CORS origins
+## Configuration and environments
+- Edit `coreon/.env`
+- Important keys: `APP_ENV`, `APP_DEBUG`, `APP_URL`, `DATABASE_URL` or `DB_*`, `CORS_ALLOWED_ORIGINS`
+- PHP timezone is set from `config/app.php`
 
-## Scripts
-Backend:
-- `composer start` — PHP built-in server
-- `composer console` — CLI (`bin/coreon`)
-- `composer test` — PHPUnit
+## HTTP: Routing, Controllers, Middleware
+- Define routes in `routes/web.php` and `routes/api.php`
+- Handlers may be `Controller@method`, `[Controller::class, 'method']`, or closures
+- Add middleware by registering in `HttpKernel`
 
-Frontend:
-- `npm run dev` — Next.js dev
-- `npm run build` — production build
-- `npm start` — start built app
+## HTTP: Error handling, CORS, JSON, Request IDs, Logging
+- ErrorHandlingMiddleware: Whoops in debug, 500 otherwise
+- CorsMiddleware: reads CORS from config
+- JsonBodyParserMiddleware: decodes JSON body into `Request::request`
+- RequestIdMiddleware: sets `X-Request-Id` on request/response
+- RequestLoggingMiddleware: logs method, path, status, duration, request_id
+
+## DI Container and Services
+- PHP-DI container built in `Application::buildContainer`
+- Put service definitions in `config/container.php`
+
+## Database with Doctrine DBAL
+- Configure via `DATABASE_URL` or `DB_*` in `.env`
+- Access via type-hinted `Doctrine\DBAL\Connection`
+
+## Logging strategy
+- Monolog logs to `storage/logs/sparkify.log`
+- Include `request_id` for correlation across services
+
+## CLI tooling
+- `php bin/sparkify route:list` — list routes
+- Extend by registering new console commands
+
+## Frontend (Next.js)
+- TypeScript + Tailwind; App Router in `web/app`
+- API requests proxied to `:8000` via `next.config.mjs` rewrites
 
 ## API examples
-- `GET /api/health` — health info
-- `GET /api/v1/hello/{name}` — greeting
+- `GET /api/health` — health info and environment
+- `GET /api/v1/hello/{name}` — greeting payload
+
+## Security and CORS
+- Restrict `CORS_ALLOWED_ORIGINS` in production
+- Add authentication/authorization middleware as needed
+
+## Testing (PHPUnit)
+- Run tests: `cd coreon && composer test`
+- Example test in `coreon/tests/`
+
+## Linting & formatting
+- PHP CS Fixer config at `coreon/.php-cs-fixer.dist.php`
+- ESLint in `web/.eslintrc.json`
+- EditorConfig and gitattributes at repo root
 
 ## CI/CD
-- Add GitHub Actions workflows to lint and build (see `.github/workflows` folder if added)
+- GitHub Actions workflow `.github/workflows/ci.yml` builds web and runs PHP tests
+
+## Observability & Deployment notes
+- Include `X-Request-Id` in logs, propagate across services
+- Containerize via provided Dockerfiles; configure health checks and logging drivers
+
+## Roadmap
+- Authentication middleware and guards
+- Schema validation (e.g., JSON Schema) middleware
+- Caching layer integrations (Symfony Cache)
+- Background jobs and queues
+- OpenAPI generation and docs site
 
 ## Contributing
-See `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
+See `CONTRIBUTING.md`.
+
+## Code of Conduct
+See `CODE_OF_CONDUCT.md`.
 
 ## License
 MIT — see `LICENSE`.

--- a/coreon/app/Http/Controllers/HealthController.php
+++ b/coreon/app/Http/Controllers/HealthController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use Coreon\Core\Support\Config;
+use Sparkify\Core\Support\Config;
 use Symfony\Component\HttpFoundation\Request;
 
 final class HealthController
@@ -14,7 +14,7 @@ final class HealthController
 		return [
 			'status' => 'ok',
 			'app' => [
-				'name' => (string)Config::get('app.name', 'Coreon'),
+				'name' => (string)Config::get('app.name', 'Sparkify'),
 				'env' => (string)Config::get('app.env', 'local'),
 				'debug' => (bool)Config::get('app.debug', false),
 			],

--- a/coreon/bin/sparkify
+++ b/coreon/bin/sparkify
@@ -9,16 +9,15 @@ use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Coreon\Core\Application as CoreonApp;
-use Coreon\Core\Routing\Router;
+use Sparkify\Core\Application as SparkifyApp;
 
 $basePath = realpath(__DIR__ . '/..');
-$coreon = new CoreonApp($basePath);
-$routerProperty = new ReflectionProperty(Coreon\Core\HttpKernel::class, 'router');
+$app = new SparkifyApp($basePath);
+$routerProperty = new ReflectionProperty(Sparkify\Core\HttpKernel::class, 'router');
 $routerProperty->setAccessible(true);
-$router = $routerProperty->getValue($coreon->getHttpKernel());
+$router = $routerProperty->getValue($app->getHttpKernel());
 
-$cli = new ConsoleApplication('Coreon', '0.1.0');
+$cli = new ConsoleApplication('Sparkify', '0.1.0');
 
 $cli->register('route:list')
 	->setDescription('List all registered routes')

--- a/coreon/bootstrap/app.php
+++ b/coreon/bootstrap/app.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Coreon\Core\Application;
+use Sparkify\Core\Application;
 
 return static function (string $basePath): Application {
 	return new Application($basePath);

--- a/coreon/composer.json
+++ b/coreon/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "coreon/framework",
-	"description": "Coreon: An advanced, modular PHP framework.",
+	"name": "sparkify/framework",
+	"description": "Sparkify: An advanced, modular PHP framework.",
 	"type": "library",
 	"license": "MIT",
 	"require": {
@@ -21,7 +21,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Coreon\\": "src/",
+			"Sparkify\\": "src/",
 			"App\\": "app/"
 		}
 	},
@@ -32,7 +32,7 @@
 	},
 	"scripts": {
 		"start": "php -S 0.0.0.0:8000 -t public public/index.php",
-		"console": "php bin/coreon",
+		"console": "php bin/sparkify",
 		"test": "phpunit --colors=always"
 	},
 	"config": {

--- a/coreon/config/app.php
+++ b/coreon/config/app.php
@@ -1,9 +1,9 @@
 <?php
 
-use Coreon\Core\Support\Env;
+use Sparkify\Core\Support\Env;
 
 return [
-	'name' => Env::get('APP_NAME', 'Coreon'),
+	'name' => Env::get('APP_NAME', 'Sparkify'),
 	'env' => Env::get('APP_ENV', 'local'),
 	'debug' => Env::bool('APP_DEBUG', true),
 	'timezone' => Env::get('APP_TIMEZONE', 'UTC'),

--- a/coreon/public/index.php
+++ b/coreon/public/index.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Coreon\Core\Application;
+use Sparkify\Core\Application;
 use Symfony\Component\HttpFoundation\Request;
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/coreon/routes/api.php
+++ b/coreon/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-/** @var Coreon\Core\Routing\Router $router */
+/** @var Sparkify\Core\Routing\Router $router */
 
 $router->get('/api/health', [\App\Http\Controllers\HealthController::class, 'index'], 'api.health');
 $router->get('/api/v1/hello/{name}', [\App\Http\Controllers\HelloController::class, 'greet'], 'api.v1.hello');

--- a/coreon/routes/web.php
+++ b/coreon/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
-/** @var Coreon\Core\Routing\Router $router */
+/** @var Sparkify\Core\Routing\Router $router */
 
 $router->get('/', function () {
-	return '<!doctype html><html><head><title>Coreon</title></head><body><h1>Welcome to Coreon</h1></body></html>';
+	return '<!doctype html><html><head><title>Sparkify</title></head><body><h1>Welcome to Sparkify</h1></body></html>';
 }, 'web.home');

--- a/coreon/src/Core/Application.php
+++ b/coreon/src/Core/Application.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core;
+namespace Sparkify\Core;
 
-use Coreon\Core\Support\Config;
-use Coreon\Core\Support\Env;
-use Coreon\Core\Support\Paths;
+use Sparkify\Core\Support\Config;
+use Sparkify\Core\Support\Env;
+use Sparkify\Core\Support\Paths;
 use DI\Container;
 use DI\ContainerBuilder;
 use Monolog\Handler\StreamHandler;
@@ -69,11 +69,11 @@ final class Application
 
 	private function createLogger(): Logger
 	{
-		$logPath = $this->path('storage/logs/coreon.log');
+		$logPath = $this->path('storage/logs/sparkify.log');
 		if (!is_dir(dirname($logPath))) {
 			mkdir(dirname($logPath), 0777, true);
 		}
-		$logger = new Logger('coreon');
+		$logger = new Logger('sparkify');
 		$logger->pushHandler(new StreamHandler($logPath, Level::Debug));
 		return $logger;
 	}

--- a/coreon/src/Core/Http/Middleware/CorsMiddleware.php
+++ b/coreon/src/Core/Http/Middleware/CorsMiddleware.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Http\Middleware;
+namespace Sparkify\Core\Http\Middleware;
 
-use Coreon\Core\Support\Config;
+use Sparkify\Core\Support\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/coreon/src/Core/Http/Middleware/ErrorHandlingMiddleware.php
+++ b/coreon/src/Core/Http/Middleware/ErrorHandlingMiddleware.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Http\Middleware;
+namespace Sparkify\Core\Http\Middleware;
 
-use Coreon\Core\Support\Config;
+use Sparkify\Core\Support\Config;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/coreon/src/Core/Http/Middleware/JsonBodyParserMiddleware.php
+++ b/coreon/src/Core/Http/Middleware/JsonBodyParserMiddleware.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Http\Middleware;
+namespace Sparkify\Core\Http\Middleware;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/coreon/src/Core/Http/Middleware/RequestIdMiddleware.php
+++ b/coreon/src/Core/Http/Middleware/RequestIdMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sparkify\Core\Http\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RequestIdMiddleware
+{
+	public function __invoke(Request $request, callable $next): Response
+	{
+		$requestId = $request->headers->get('X-Request-Id') ?? bin2hex(random_bytes(8));
+		$request->headers->set('X-Request-Id', $requestId);
+		$response = $next($request);
+		$response->headers->set('X-Request-Id', $requestId);
+		return $response;
+	}
+}

--- a/coreon/src/Core/Http/Middleware/RequestLoggingMiddleware.php
+++ b/coreon/src/Core/Http/Middleware/RequestLoggingMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sparkify\Core\Http\Middleware;
+
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RequestLoggingMiddleware
+{
+	private Logger $logger;
+
+	public function __construct(Logger $logger)
+	{
+		$this->logger = $logger;
+	}
+
+	public function __invoke(Request $request, callable $next): Response
+	{
+		$start = microtime(true);
+		$response = $next($request);
+		$durationMs = (int)round((microtime(true) - $start) * 1000);
+		$requestId = (string)($request->headers->get('X-Request-Id') ?? '');
+		$this->logger->info('HTTP', [
+			'method' => $request->getMethod(),
+			'path' => $request->getPathInfo(),
+			'status' => $response->getStatusCode(),
+			'duration_ms' => $durationMs,
+			'request_id' => $requestId,
+		]);
+		return $response;
+	}
+}

--- a/coreon/src/Core/Http/Middleware/RoutingMiddleware.php
+++ b/coreon/src/Core/Http/Middleware/RoutingMiddleware.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Http\Middleware;
+namespace Sparkify\Core\Http\Middleware;
 
-use Coreon\Core\Routing\Router;
+use Sparkify\Core\Routing\Router;
 use DI\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/coreon/src/Core/Http/ResponseFactory.php
+++ b/coreon/src/Core/Http/ResponseFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Http;
+namespace Sparkify\Core\Http;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;

--- a/coreon/src/Core/HttpKernel.php
+++ b/coreon/src/Core/HttpKernel.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core;
+namespace Sparkify\Core;
 
-use Coreon\Core\Http\Middleware\ErrorHandlingMiddleware;
-use Coreon\Core\Http\Middleware\JsonBodyParserMiddleware;
-use Coreon\Core\Http\Middleware\RoutingMiddleware;
-use Coreon\Core\Http\Middleware\CorsMiddleware;
-use Coreon\Core\Routing\Router;
+use Sparkify\Core\Http\Middleware\ErrorHandlingMiddleware;
+use Sparkify\Core\Http\Middleware\JsonBodyParserMiddleware;
+use Sparkify\Core\Http\Middleware\RoutingMiddleware;
+use Sparkify\Core\Http\Middleware\CorsMiddleware;
+use Sparkify\Core\Http\Middleware\RequestIdMiddleware;
+use Sparkify\Core\Http\Middleware\RequestLoggingMiddleware;
+use Sparkify\Core\Routing\Router;
 use DI\Container;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,7 +49,6 @@ final class HttpKernel
 
 	public function terminate(Request $request, Response $response): void
 	{
-		// Placeholder for terminating logic (logging, events, etc.)
 		$this->logger->debug('Request terminated', [
 			'status' => $response->getStatusCode(),
 			'path' => $request->getPathInfo(),
@@ -62,6 +63,8 @@ final class HttpKernel
 	private function registerCoreMiddleware(): void
 	{
 		$this->addMiddleware(new ErrorHandlingMiddleware($this->container));
+		$this->addMiddleware(new RequestIdMiddleware());
+		$this->addMiddleware(new RequestLoggingMiddleware($this->logger));
 		$this->addMiddleware(new CorsMiddleware());
 		$this->addMiddleware(new JsonBodyParserMiddleware());
 		$this->addMiddleware(new RoutingMiddleware($this->router, $this->container));

--- a/coreon/src/Core/Routing/Router.php
+++ b/coreon/src/Core/Routing/Router.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Routing;
+namespace Sparkify\Core\Routing;
 
 use DI\Container;
 use FastRoute\Dispatcher;
@@ -104,17 +104,17 @@ final class Router
 			[$class, $method] = explode('@', $handler, 2);
 			$controller = $this->container->get($class);
 			$result = $controller->{$method}($request, ...array_values($vars));
-			return \Coreon\Core\Http\ResponseFactory::from($result);
+			return \Sparkify\Core\Http\ResponseFactory::from($result);
 		}
 		if (is_array($handler) && is_string($handler[0])) {
 			$controller = $this->container->get($handler[0]);
 			$method = $handler[1];
 			$result = $controller->{$method}($request, ...array_values($vars));
-			return \Coreon\Core\Http\ResponseFactory::from($result);
+			return \Sparkify\Core\Http\ResponseFactory::from($result);
 		}
 		if (is_callable($handler)) {
 			$result = $handler($request, ...array_values($vars));
-			return \Coreon\Core\Http\ResponseFactory::from($result);
+			return \Sparkify\Core\Http\ResponseFactory::from($result);
 		}
 		return new Response('Bad handler', 500);
 	}

--- a/coreon/src/Core/Support/Config.php
+++ b/coreon/src/Core/Support/Config.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Support;
+namespace Sparkify\Core\Support;
 
 final class Config
 {

--- a/coreon/src/Core/Support/Env.php
+++ b/coreon/src/Core/Support/Env.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Support;
+namespace Sparkify\Core\Support;
 
 use Dotenv\Dotenv;
 

--- a/coreon/src/Core/Support/Paths.php
+++ b/coreon/src/Core/Support/Paths.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Coreon\Core\Support;
+namespace Sparkify\Core\Support;
 
 final class Paths
 {

--- a/coreon/tests/RouterTest.php
+++ b/coreon/tests/RouterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Coreon\Core\Routing\Router;
+use Sparkify\Core\Routing\Router;
 use DI\Container;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +12,6 @@ final class RouterTest extends TestCase
 	{
 		$container = new Container();
 		$router = new Router(__DIR__ . '/..', $container);
-		$reflection = new ReflectionMethod($router, 'list');
 		$routes = $router->list();
 		$this->assertIsArray($routes);
 	}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,8 +2,8 @@ import './globals.css';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-	title: 'Coreon Web',
-	description: 'Next.js frontend for Coreon framework',
+	title: 'Sparkify Web',
+	description: 'Next.js frontend for Sparkify framework',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -8,7 +8,7 @@ export default async function HomePage() {
 	const health = await fetchHealth();
 	return (
 		<main className="space-y-6">
-			<h1 className="text-3xl font-bold">Coreon + Next.js</h1>
+			<h1 className="text-3xl font-bold">Sparkify + Next.js</h1>
 			<div className="rounded border bg-white p-4 shadow">
 				<pre className="text-sm overflow-x-auto">{JSON.stringify(health, null, 2)}</pre>
 			</div>

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,8 @@
 {
-	"name": "coreon-web",
+	"name": "sparkify-web",
 	"private": true,
 	"version": "0.1.0",
+	"description": "Sparkify Next.js frontend",
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",


### PR DESCRIPTION
…ADME; feat: request id and logging middleware; chore: rename console

## Summary

This PR introduces Coreon (advanced PHP framework) and a Next.js TypeScript frontend, with full dev tooling and Docker support.

## Changes
- Coreon framework with DI, routing, middleware (errors, CORS, JSON), logging, env/config, console, Doctrine DBAL
- API endpoints: `/api/health`, `/api/v1/hello/{name}`
- Next.js 14 app (TypeScript, Tailwind, App Router) proxying `/api/*` to Coreon
- Dockerfiles and docker-compose for one-command local dev
- Basic PHPUnit setup and a starter test

## How to test
1. Docker
   - `docker compose up --build`
   - Visit `http://localhost:3000` (frontend) and `http://localhost:8000/api/health` (backend)
2. Local
   - Backend: `cd coreon && composer install && composer run start`
   - Frontend: `cd web && npm install && npm run dev`

## Screenshots
N/A

## Checklist
- [ ] Verified Next.js builds (`npm run build`)
- [ ] Verified API health returns 200
- [ ] Lint/typecheck pass for web
- [ ] Tests pass (`phpunit`)