### PR TITLE
Pull on all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,9 @@ Run tests:
 composer test
 ```
 
+JWT setup (dev):
+- Copy `sparkify/.env.example` to `sparkify/.env` and set `JWT_SECRET`
+
 Static analysis and style:
 - Run PHP CS Fixer if installed locally (`php-cs-fixer fix`)
 

--- a/sparkify/app/Http/Controllers/HealthController.php
+++ b/sparkify/app/Http/Controllers/HealthController.php
@@ -6,20 +6,48 @@ namespace App\Http\Controllers;
 
 use Sparkify\Core\Support\Config;
 use Symfony\Component\HttpFoundation\Request;
+use Doctrine\DBAL\Connection;
+use Psr\SimpleCache\CacheInterface;
 
 final class HealthController
 {
+	private Connection $db;
+	private CacheInterface $cache;
+
+	public function __construct(Connection $db, CacheInterface $cache)
+	{
+		$this->db = $db;
+		$this->cache = $cache;
+	}
+
 	public function index(Request $request): array
 	{
+		$dbOk = true;
+		$cacheOk = true;
+		try { $this->db->executeQuery('SELECT 1'); } catch (\Throwable $e) { $dbOk = false; }
+		try { $this->cache->set('health_ping', 'ok', 5); $cacheOk = $this->cache->get('health_ping') === 'ok'; } catch (\Throwable $e) { $cacheOk = false; }
+
 		return [
-			'status' => 'ok',
+			'status' => ($dbOk && $cacheOk) ? 'ok' : 'degraded',
 			'app' => [
 				'name' => (string)Config::get('app.name', 'Sparkify'),
 				'env' => (string)Config::get('app.env', 'local'),
 				'debug' => (bool)Config::get('app.debug', false),
 			],
+			'checks' => [
+				'db' => $dbOk,
+				'cache' => $cacheOk,
+			],
 			'php' => PHP_VERSION,
 			'time' => gmdate('c'),
+		];
+	}
+
+	public function metrics(): array
+	{
+		return [
+			'uptime_seconds' => (int)(microtime(true) - $_SERVER['REQUEST_TIME_FLOAT']),
+			'memory_usage_bytes' => memory_get_usage(true),
 		];
 	}
 }

--- a/sparkify/composer.json
+++ b/sparkify/composer.json
@@ -14,7 +14,9 @@
 		"filp/whoops": "^2.15",
 		"doctrine/dbal": "^4.2",
 		"symfony/console": "^7.1",
-		"league/event": "^3.0"
+		"league/event": "^3.0",
+		"firebase/php-jwt": "^6.10",
+		"respect/validation": "^2.3"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11.0"

--- a/sparkify/config/auth.php
+++ b/sparkify/config/auth.php
@@ -1,0 +1,13 @@
+<?php
+
+use Sparkify\Core\Support\Env;
+
+return [
+	'jwt' => [
+		'issuer' => (string)Env::get('JWT_ISSUER', 'sparkify'),
+		'audience' => (string)Env::get('JWT_AUDIENCE', 'sparkify-clients'),
+		'ttl' => (int)Env::get('JWT_TTL', 3600),
+		'alg' => (string)Env::get('JWT_ALG', 'HS256'),
+		'secret' => (string)Env::get('JWT_SECRET', ''),
+	],
+];

--- a/sparkify/routes/api.php
+++ b/sparkify/routes/api.php
@@ -3,4 +3,8 @@
 /** @var Sparkify\Core\Routing\Router $router */
 
 $router->get('/api/health', [\App\Http\Controllers\HealthController::class, 'index'], 'api.health');
+$router->get('/api/metrics', [\App\Http\Controllers\HealthController::class, 'metrics'], 'api.metrics');
 $router->get('/api/v1/hello/{name}', [\App\Http\Controllers\HelloController::class, 'greet'], 'api.v1.hello');
+
+// Example: Protect a route via JWT middleware (wire in kernel or dedicated group handling)
+// $router->get('/api/v1/secure', [\App\Http\Controllers\SecureController::class, 'index'], 'api.v1.secure');

--- a/sparkify/src/Core/Http/Middleware/CompressionMiddleware.php
+++ b/sparkify/src/Core/Http/Middleware/CompressionMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sparkify\Core\Http\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CompressionMiddleware
+{
+	public function __invoke(Request $request, callable $next): Response
+	{
+		$response = $next($request);
+		$acceptEncoding = (string)($request->headers->get('Accept-Encoding') ?? '');
+		if (str_contains($acceptEncoding, 'gzip')) {
+			$body = $response->getContent();
+			if ($body !== false && $body !== null && ($response->headers->get('Content-Encoding') === null)) {
+				$gz = gzencode($body, 6);
+				$response->setContent($gz);
+				$response->headers->set('Content-Encoding', 'gzip');
+				$response->headers->set('Vary', 'Accept-Encoding');
+			}
+		}
+		return $response;
+	}
+}

--- a/sparkify/src/Core/Http/Middleware/ETagMiddleware.php
+++ b/sparkify/src/Core/Http/Middleware/ETagMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sparkify\Core\Http\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ETagMiddleware
+{
+	public function __invoke(Request $request, callable $next): Response
+	{
+		$response = $next($request);
+		if (!in_array($request->getMethod(), ['GET', 'HEAD'], true)) {
+			return $response;
+		}
+		$etag = sha1($response->getContent() ?? '');
+		$response->setEtag($etag);
+		if ($response->isNotModified($request)) {
+			$response->setNotModified();
+		}
+		return $response;
+	}
+}

--- a/sparkify/src/Core/Http/Middleware/JwtAuthMiddleware.php
+++ b/sparkify/src/Core/Http/Middleware/JwtAuthMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sparkify\Core\Http\Middleware;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Sparkify\Core\Support\Config;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class JwtAuthMiddleware
+{
+	public function __invoke(Request $request, callable $next): Response
+	{
+		$auth = (string)($request->headers->get('Authorization') ?? '');
+		if (!str_starts_with($auth, 'Bearer ')) {
+			return new JsonResponse(['error' => 'Unauthorized'], 401);
+		}
+		$token = substr($auth, 7);
+		try {
+			$cfg = Config::get('auth.jwt');
+			$alg = $cfg['alg'] ?? 'HS256';
+			$secret = (string)($cfg['secret'] ?? '');
+			$decoded = JWT::decode($token, new Key($secret, $alg));
+			$request->attributes->set('auth', $decoded);
+			return $next($request);
+		} catch (\Throwable $e) {
+			return new JsonResponse(['error' => 'Unauthorized'], 401);
+		}
+	}
+}

--- a/sparkify/src/Core/HttpKernel.php
+++ b/sparkify/src/Core/HttpKernel.php
@@ -11,6 +11,8 @@ use Sparkify\Core\Http\Middleware\CorsMiddleware;
 use Sparkify\Core\Http\Middleware\RequestIdMiddleware;
 use Sparkify\Core\Http\Middleware\RequestLoggingMiddleware;
 use Sparkify\Core\Http\Middleware\RateLimitMiddleware;
+use Sparkify\Core\Http\Middleware\ETagMiddleware;
+use Sparkify\Core\Http\Middleware\CompressionMiddleware;
 use Sparkify\Core\Routing\Router;
 use DI\Container;
 use Monolog\Logger;
@@ -70,5 +72,7 @@ final class HttpKernel
 		$this->addMiddleware(new CorsMiddleware());
 		$this->addMiddleware(new JsonBodyParserMiddleware());
 		$this->addMiddleware(new RoutingMiddleware($this->router, $this->container));
+		$this->addMiddleware(new ETagMiddleware());
+		$this->addMiddleware(new CompressionMiddleware());
 	}
 }

--- a/sparkify/src/Core/Validation/FormRequest.php
+++ b/sparkify/src/Core/Validation/FormRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sparkify\Core\Validation;
+
+use Respect\Validation\Factory;
+use Respect\Validation\Validatable;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+abstract class FormRequest
+{
+	abstract public function rules(): array;
+
+	public function validate(Request $request): array
+	{
+		$payload = array_merge($request->query->all(), $request->request->all());
+		$rules = $this->rules();
+		$errors = [];
+		foreach ($rules as $field => $rule) {
+			if ($rule instanceof Validatable) {
+				$value = $payload[$field] ?? null;
+				if (!$rule->validate($value)) {
+					$errors[$field] = 'Invalid';
+				}
+			}
+		}
+		if (!empty($errors)) {
+			throw new BadRequestException(json_encode(['errors' => $errors], JSON_THROW_ON_ERROR));
+		}
+		return $payload;
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces or updates Sparkify (advanced PHP framework) and the Sparkify Next.js (TypeScript) frontend, with full dev tooling and Docker support.

## Changes
- Sparkify framework with DI, routing, middleware (errors, CORS, JSON, request ID, request logging), logging, env/config, console, Doctrine DBAL
- API endpoints: `/api/health`, `/api/v1/hello/{name}`
- Next.js 14 app (TypeScript, Tailwind, App Router) proxying `/api/*` to Sparkify
- Dockerfiles and docker-compose for one-command local dev
- PHPUnit setup and a starter test
- Linting/config: EditorConfig, ESLint (web), PHP CS Fixer (php), GitHub Actions CI

## How to test
1. Docker
   - `docker compose up --build`
   - Visit `http://localhost:3000` (frontend) and `http://localhost:8000/api/health` (backend)
2. Local
   - Backend: `cd coreon && composer install && composer run start`
   - Frontend: `cd web && npm install && npm run dev`

## Screenshots
N/A

## Checklist
- [ ] Verified Next.js builds (`npm run build`)
- [ ] Verified API health returns 200
- [ ] Lint/typecheck pass for web
- [ ] Tests pass (`phpunit`)